### PR TITLE
Workaround for yarn suddenly going missing in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ jobs:
       # latest LTS version of node
       - image: circleci/node:carbon
 
+    environment:
+      - PATH: "/opt/yarn/yarn-v1.5.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
     working_directory: ~/repo
 
     steps:
@@ -35,6 +38,9 @@ jobs:
       # latest LTS version of node
       - image: circleci/node:carbon
 
+    environment:
+      - PATH: "/opt/yarn/yarn-v1.5.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
     working_directory: ~/repo
 
     steps:
@@ -43,10 +49,10 @@ jobs:
         run:
           command: |
               yarn install
-              sudo yarn global add now
-              URL=$(now --token ${NOW_TOKEN} --public --npm)
-              now --token ${NOW_TOKEN} alias set ${URL} poc
-              now --token ${NOW_TOKEN} rm proof-of-concept-v2 --safe --yes
+              yarn add now
+              URL=$(./node_modules/now/download/dist/now --token ${NOW_TOKEN} --public --npm)
+              ./node_modules/now/download/dist/now --token ${NOW_TOKEN} alias set ${URL} poc
+              ./node_modules/now/download/dist/now --token ${NOW_TOKEN} rm proof-of-concept-v2 --safe --yes
           name: "Deploy Proof of Concept (v2) to now.sh"
 
 workflows:

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "history": "^4.6.3",
     "isomorphic-fetch": "^2.2.1",
     "lingui-react": "^1.4.1",
+    "now": "^10.1.6",
     "raf": "^3.4.0",
     "react": "^16.0.0",
     "react-apollo": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5636,6 +5636,10 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
+now@^10.1.6:
+  version "10.1.6"
+  resolved "https://registry.yarnpkg.com/now/-/now-10.1.6.tgz#58e4fce695588bd3ff5ebeee32d44b0e971b311a"
+
 npm-path@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"


### PR DESCRIPTION
Earlier this morning, all of our build and then deploy started mysteriously failing. 
It turns out that `yarn` vanished from an updated docker container we were using, and then lots of people's builds started failing.

Here's the relevant github issue: [https://github.com/nodejs/docker-node/issues/651](https://github.com/nodejs/docker-node/issues/651)
Here's a tweet from circleci with a workaround: [https://twitter.com/circleci/status/974703363542495232](https://twitter.com/circleci/status/974703363542495232)

This workaround gives us yarn back, but it's not able to globally install `now`, so I've installed that locally and then am just calling the local file to run the deployment. 

Got our green checkmarks back finally, so all systems go.