### PR TITLE
Tooltips on the "search" page

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-dom": "^16.0.0",
     "react-emotion": "^9.0.2",
     "react-redux": "^5.0.5",
+    "react-tooltip": "^3.4.0",
     "react-universal-component": "^2.5.0",
     "redux": "^3.7.0",
     "redux-devtools-extension": "^2.13.2",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -72,12 +72,6 @@ injectGlobal`
     }
   }
 
-	#info {
-		top: 5px;
-		left: 5px;
-		display: inline;
-	}
-
   .bottom-link {
     padding-left: ${theme.spacing.xs}px;
   }

--- a/src/components/InfoIcon.js
+++ b/src/components/InfoIcon.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { theme } from './styles'
 
-const InfoIcon = ({ width = '0.8em', text = '#fff', circle = '#4A4A4A' }) => (
+const InfoIcon = ({ width = '0.8em', text = null, circle = null }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     id="info"
@@ -11,16 +12,22 @@ const InfoIcon = ({ width = '0.8em', text = '#fff', circle = '#4A4A4A' }) => (
   >
     <g fillRule="evenodd" fill="none" strokeWidth="1" stroke="none">
       <g>
-        <circle r="10" cy="10" cx="10" fill={circle} id="Oval" />
+        <circle
+          r="10"
+          cy="10"
+          cx="10"
+          fill={circle || theme.colour.grey}
+          id="Oval"
+        />
         <text
-          fill={text}
+          fill={text || theme.colour.white}
           fontWeight="normal"
-          fontSize="20"
-          fontFamily="Helvetica"
+          fontSize="16"
+          fontFamily={theme.weight.m}
           id="i"
         >
-          <tspan id="tspan9" y="17" x="8">
-            i
+          <tspan id="tspan9" y="15.5" x="6">
+            ?
           </tspan>
         </text>
       </g>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -6,7 +6,7 @@ import Breadcrumbs from './Breadcrumbs'
 import FieldSet from './forms/FieldSet'
 import { Radio } from './forms/MultipleChoice'
 import Button from './forms/Button'
-import InfoIcon from './InfoIcon'
+import TooltipIcon from './TooltipIcon'
 import { connect } from 'react-redux'
 import { compose, withApollo } from 'react-apollo'
 import { Trans } from 'lingui-react'
@@ -70,9 +70,7 @@ class Search extends Component {
                 name="search"
                 id="search-0"
               >
-                <abbr title="A location refers to a region or neighbourhood. You will be searching by the first three digits of any postal code.">
-                  <InfoIcon width="22px" />
-                </abbr>
+                <TooltipIcon dataTip="A location refers to a region or neighbourhood.<br/>You will be searching by the first three digits of any postal code." />
               </Radio>
               <Radio
                 label={<Trans>File number</Trans>}
@@ -80,9 +78,7 @@ class Search extends Component {
                 name="search"
                 id="search-1"
               >
-                <abbr title="A file number refers to an individual home. This number is provided to the homeowner through EnerGuide.">
-                  <InfoIcon width="22px" />
-                </abbr>
+                <TooltipIcon dataTip="A file number refers to an individual home.<br/>This number is provided to the homeowner through EnerGuide." />
               </Radio>
             </FieldSet>
             <Button disabled={pristine || submitting}>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -71,7 +71,7 @@ class Search extends Component {
                 id="search-0"
               >
                 <abbr title="A location refers to a region or neighbourhood. You will be searching by the first three digits of any postal code.">
-                  <InfoIcon />
+                  <InfoIcon width="22px" />
                 </abbr>
               </Radio>
               <Radio
@@ -81,7 +81,7 @@ class Search extends Component {
                 id="search-1"
               >
                 <abbr title="A file number refers to an individual home. This number is provided to the homeowner through EnerGuide.">
-                  <InfoIcon />
+                  <InfoIcon width="22px" />
                 </abbr>
               </Radio>
             </FieldSet>

--- a/src/components/TooltipIcon.js
+++ b/src/components/TooltipIcon.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import InfoIcon from './InfoIcon'
+import ReactTooltip from 'react-tooltip'
+import { css } from 'react-emotion'
+import { theme } from './styles'
+
+const abbr = css`
+  display: inline-block;
+  height: 22px;
+  cursor: pointer;
+
+  &:focus {
+    outline: 3px solid ${theme.colour.focus};
+  }
+
+  svg {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+
+  .__react_component_tooltip {
+    font-size: ${theme.font.md};
+    margin-right: 20px;
+    background-color: ${theme.colour.blue};
+  }
+`
+
+const replaceBrsAndSurroundingWhitespace = str =>
+  str.replace(/\s*<br ?\/?>\s*/g, ' ')
+
+const TooltipIcon = ({ dataTip }) => (
+  <abbr
+    className={abbr}
+    data-tip={dataTip}
+    title={replaceBrsAndSurroundingWhitespace(dataTip)}
+    tabIndex={0}
+    data-effect="solid"
+    data-event="click focus"
+    data-event-off="blur"
+    data-multiline={true}
+    data-offset="{'top': -5}"
+    data-place="right"
+    data-type="info"
+  >
+    <InfoIcon width="22px" />
+    <ReactTooltip globalEventOff="click" />
+  </abbr>
+)
+
+TooltipIcon.propTypes = {
+  dataTip: PropTypes.string.isRequired,
+}
+
+export default TooltipIcon

--- a/src/components/forms/MultipleChoice.js
+++ b/src/components/forms/MultipleChoice.js
@@ -138,12 +138,13 @@ const cds_multiple_choice = css`
   }
 
   label {
+    display: inline-block;
     padding: 0;
     height: ${theme.spacing.xl}px;
     font-size: ${theme.font.lg};
 
     span {
-      padding: 0 ${theme.spacing.xs}px;
+      padding: 0 ${theme.spacing.sm}px 0 ${theme.spacing.xs}px;
     }
   }
 `
@@ -155,13 +156,13 @@ const radio = css`
     border: 2px solid ${theme.colour.grey};
     width: 22px;
     height: 22px;
-    top: 7px;
+    top: 2px;
     left: 0;
   }
 
   input[type='radio'] + label::after {
     border: 6px solid ${theme.colour.blue};
-    top: 12px;
+    top: 7px;
     left: 5px;
   }
 `
@@ -175,8 +176,8 @@ const Radio = ({ label, value, name, id, children }) => (
     <Field type="radio" component="input" name={name} id={id} value={value} />
     <label htmlFor={id} className={govuk_label_pseudo_elements}>
       {label}
-      {children}
     </label>
+    {children}
   </div>
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1679,6 +1679,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -6145,6 +6149,13 @@ react-test-renderer@^16.0.0-0:
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react-tooltip@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.4.0.tgz#037f38f797c3e6b1b58d2534ccc8c2c76af4f52d"
+  dependencies:
+    classnames "^2.2.5"
     prop-types "^15.6.0"
 
 react-universal-component@^2.5.0:


### PR DESCRIPTION
We ❤️ tooltips here at CDS.

They're a bit finicky but this is just the cold, hard truth about these things. They open on click or focus, and close when
- they are clicked
- anywhere else on the page is clicked (except for the original target element :/)
- focus leaves the original target element

### gif

![tooltips](https://user-images.githubusercontent.com/2454380/37638912-9f415da8-2be5-11e8-9815-c35c06be7d16.gif)
